### PR TITLE
Validación de numero de teléfono

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -17,6 +17,8 @@ def validate_client(data):
         errors["phone"] = "Por favor ingrese un teléfono"
     elif not phone.startswith("54"):
         errors["phone"]="El teléfono debe comenzar con 54"
+    elif not phone.isdigit():  # Verifica si el teléfono contiene solo dígitos
+        errors["phone"] = "El teléfono debe ser numérico"
 
 
     if email == "":

--- a/app/templates/clients/form.html
+++ b/app/templates/clients/form.html
@@ -37,7 +37,7 @@
                 </div>
                 <div>
                     <label for="phone" class="form-label">Teléfono</label>
-                    <input type="number"
+                    <input type="text"
                         id="phone"
                         name="phone"
                         class="form-control {% if errors.phone %}is-invalid{% endif %}"

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -1,6 +1,7 @@
+from django.forms import ValidationError
 from django.test import TestCase
 
-from app.models import Client, Medi, Product, Provider, Vet
+from app.models import Client, Medi, Product, Provider, Vet, validate_client
 
 
 class ClientModelTest(TestCase):
@@ -80,6 +81,38 @@ class ClientModelTest(TestCase):
         self.assertNotEqual(len(clients), 1)
 
 
+    def test_phone_number_must_be_numeric(self):
+        """Verifica que el número de teléfono sea numérico."""
+
+        # Prueba con un teléfono numérico válido
+        data = {
+            "name": "Juan Sebastian Veron",
+            "phone": "54221555232",
+            "address": "13 y 44",
+            "email": "brujita75@vetsoft.com",
+        }
+        errors = validate_client(data)
+        self.assertEqual(errors, {})
+
+        # Prueba con un teléfono no numérico
+        data = {
+            "name": "Juan Sebastian Veron",
+            "phone": "54221A555232",
+            "address": "13 y 44",
+            "email": "brujita75@vetsoft.com",
+        }
+        errors = validate_client(data)
+        self.assertEqual(errors, {"phone": "El teléfono debe ser numérico"})
+
+        # Prueba con un teléfono que contiene espacios
+        data = {
+            "name": "Juan Sebastian Veron",
+            "phone": "54221 555 232",
+            "address": "13 y 44",
+            "email": "brujita75@vetsoft.com",
+        }
+        errors = validate_client(data)
+        self.assertEqual(errors, {"phone": "El teléfono debe ser numérico"})
 
 class MedicineModelTest(TestCase):
     """Pruebas para el modelo Medi (Medicine)."""

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -203,8 +203,9 @@ class ClientsRepoTestCase(PlaywrightTestCase):
 
 
 class ClientCreateEditTestCase(PlaywrightTestCase):
-    def test_should_phone_start_with_54(self):
-        """Verifica que el teléfono de un cliente creado comience con '54'."""
+   
+    def test_should_show_error_if_phone_not_start_with_54(self):
+        """Verifica que se muestre un error si el teléfono no comienza con '54'."""
 
         self.page.goto(f"{self.live_server_url}{reverse('clients_form')}")
 
@@ -212,7 +213,7 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
 
         self.page.get_by_label("Nombre").fill("Juan Sebastián Veron")
 
-        self.page.get_by_label("Teléfono").fill("54221555232")
+        self.page.get_by_label("Teléfono").fill("2215555232")  # Teléfono sin '54'
 
         self.page.get_by_label("Email").fill("brujita75@vetsoft.com")
 
@@ -220,69 +221,9 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
 
         self.page.get_by_role("button", name="Guardar").click()
 
-        # Obtener el teléfono del cliente creado
-        client_phone = Client.objects.get(name="Juan Sebastián Veron").phone
-
-        # Validar que el teléfono comienza con '54'
-        self.assertTrue(str(client_phone).startswith('54'))
-
-
-
-    def test_should_be_able_to_create_a_new_client(self):
-        """Verifica que se pueda eliminar un cliente."""
-
-        self.page.goto(f"{self.live_server_url}{reverse('clients_form')}")
-
-        expect(self.page.get_by_role("form")).to_be_visible()
-
-        self.page.get_by_label("Nombre").fill("Juan Sebastián Veron")
-
-        self.page.get_by_label("Teléfono").fill("54221555232")
-
-        self.page.get_by_label("Email").fill("brujita75@vetsoft.com")
-
-        self.page.get_by_label("Dirección").fill("13 y 44")
-
-        self.page.get_by_role("button", name="Guardar").click()
-
-        expect(self.page.get_by_text("Juan Sebastián Veron")).to_be_visible()
-
-        expect(self.page.get_by_text("54221555232")).to_be_visible()
-
-        expect(self.page.get_by_text("brujita75@vetsoft.com")).to_be_visible()
-
-        expect(self.page.get_by_text("13 y 44")).to_be_visible()
-
-        
-
-    def test_should_view_errors_if_form_is_invalid(self):
-        """Verifica que se muestren errores si el formulario es inválido."""
-
-        self.page.goto(f"{self.live_server_url}{reverse('clients_form')}")
-
-        expect(self.page.get_by_role("form")).to_be_visible()
-
-        self.page.get_by_role("button", name="Guardar").click()
-
-        expect(self.page.get_by_text("Por favor ingrese un nombre")).to_be_visible()
-        expect(self.page.get_by_text("Por favor ingrese un teléfono")).to_be_visible()
-        expect(self.page.get_by_text("Por favor ingrese un email")).to_be_visible()
-
-        self.page.get_by_label("Nombre").fill("Juan Sebastián Veron")
-        self.page.get_by_label("Teléfono").fill("54221555232")
-        self.page.get_by_label("Email").fill("brujita75")
-        self.page.get_by_label("Dirección").fill("13 y 44")
-
-        self.page.get_by_role("button", name="Guardar").click()
-
-        expect(self.page.get_by_text("Por favor ingrese un nombre")).not_to_be_visible()
-        expect(
-            self.page.get_by_text("Por favor ingrese un teléfono")
-        ).not_to_be_visible()
-
-        expect(
-            self.page.get_by_text("Por favor ingrese un email valido")
-        ).to_be_visible()
+        # Verificar que se muestra el error correspondiente
+        error_message = self.page.get_by_text("El teléfono debe comenzar con 54").is_visible()
+        self.assertTrue(error_message)
 
 
 

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -178,6 +178,20 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
     def test_should_show_error_if_phone_not_start_with_54(self):
         """Verifica que se muestre un error si el teléfono no comienza con '54'."""
 
+        self.page.goto(f"{self.live_server_url}{reverse('clients_form')}")
+
+        expect(self.page.get_by_role("form")).to_be_visible()
+
+        # Prueba con un teléfono que no comienza con '54'
+        self.page.get_by_label("Nombre").fill("Juan Sebastian Veron")
+        self.page.get_by_label("Teléfono").fill("1234567890")  # Teléfono inválido
+        self.page.get_by_label("Email").fill("brujita75@vetsoft.com")
+        self.page.get_by_label("Dirección").fill("13 y 44")
+
+        self.page.get_by_role("button", name="Guardar").click()
+
+        expect(self.page.get_by_text("El teléfono debe comenzar con 54")).to_be_visible()
+
     def test_should_be_able_to_create_a_new_client(self):
 
         self.page.goto(f"{self.live_server_url}{reverse('clients_form')}")
@@ -270,28 +284,6 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
             self.page.get_by_text("Por favor ingrese un email terminado en @vetsoft.com")
         ).to_be_visible()
  
-    def test_should_phone_start_with_54(self):
-        """Verifica que el teléfono de un cliente creado comience con '54'."""
-
-        self.page.goto(f"{self.live_server_url}{reverse('clients_form')}")
-
-        expect(self.page.get_by_role("form")).to_be_visible()
-
-        self.page.get_by_label("Nombre").fill("Juan Sebastian Veron")
-
-        self.page.get_by_label("Teléfono").fill("54221555232")
-
-        self.page.get_by_label("Email").fill("brujita75@vetsoft.com")
-
-        self.page.get_by_label("Dirección").fill("13 y 44")
-
-        self.page.get_by_role("button", name="Guardar").click()
-
-        # Obtener el teléfono del cliente creado
-        client_phone = Client.objects.get(name="Juan Sebastian Veron").phone
-
-        # Validar que el teléfono comienza con '54'
-        self.assertTrue(str(client_phone).startswith('54'))
 
     def test_should_show_error_if_phone_is_not_numeric(self):
         """Verifica que se muestra un error si el teléfono no es numérico."""

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -213,7 +213,7 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
 
         self.page.get_by_label("Nombre").fill("Juan Sebastián Veron")
 
-        self.page.get_by_label("Teléfono").fill("2215555232")  # Teléfono sin '54'
+        self.page.get_by_label("Teléfono").fill("2215555232")  
 
         self.page.get_by_label("Email").fill("brujita75@vetsoft.com")
 
@@ -279,6 +279,22 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
             "href", reverse("clients_edit", kwargs={"id": client.id})
         )
 
+    def test_should_show_error_if_phone_is_not_numeric(self):
+        """Verifica que se muestra un error si el teléfono no es numérico."""
+
+        self.page.goto(f"{self.live_server_url}{reverse('clients_form')}")
+
+        # Completar el formulario con un teléfono no numérico
+        self.page.get_by_label("Nombre").fill("Juan Sebastián Veron")
+        self.page.get_by_label("Teléfono").fill("54221A555232")  # Teléfono no numérico
+        self.page.get_by_label("Email").fill("brujita75@vetsoft.com")
+        self.page.get_by_label("Dirección").fill("13 y 44")
+
+        self.page.get_by_role("button", name="Guardar").click()
+
+        # Verificar que se muestra el mensaje de error correspondiente
+        error_message = self.page.get_by_text("El teléfono debe ser numérico").is_visible()
+        self.assertTrue(error_message)
 
 class MedicineCreateEditTestCase(PlaywrightTestCase):
     def test_should_be_able_to_create_a_new_medicine(self):


### PR DESCRIPTION
En este PR se realizaron las siguientes modificaciones:

- Se modifico el test para validar que se muestra un error si el numero de teléfono ingresado comienza con '54'. Anteriormente, el test solo verificaba que el numero que escribimos manualmente comience con '54'.
- Agrego una validación que asegure que el numero de teléfono ingresado sea solo numérico
- Agrego test de unidad para validar que el telefoneo sea numérico y, de no ser así, mostrar un error
- Agrego test e2e para validar que el teléfono sea numérico, en caso contrario, mostrar un error