### PR TITLE
Bugfix/validacion cliente editar

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -193,10 +193,10 @@ class Client(models.Model):
 
     def update_client(self, client_data):
         """Actualizar datos de un cliente"""
-        self.name = client_data.get("name", "") or self.name
-        self.email = client_data.get("email", "") or self.email
-        self.phone = client_data.get("phone", "") or self.phone
-        self.address = client_data.get("address", "") or self.address
+        self.name = client_data.get("name", self.name)
+        self.email = client_data.get("email", self.email)
+        self.phone = client_data.get("phone", self.phone)
+        self.address = client_data.get("address", self.address)
 
          # Validar los datos actualizados
         updated_data = {

--- a/app/tests_integration.py
+++ b/app/tests_integration.py
@@ -169,6 +169,30 @@ class ClientsTest(TestCase):
         self.assertEqual(editedClient.address, client.address)
         self.assertEqual(editedClient.email, client.email)
     
+    def test_edit_client_with_invalid_data(self):
+        """Verifica si se puede editar un cliente con datos inválidos."""
+        client = Client.objects.create(
+            name="Juan Sebastian Veron",
+            address="13 y 44",
+            phone=54221555232,
+            email="brujita75@vetsoft.com",
+
+        )
+
+        response = self.client.post(
+            reverse("clients_form"),
+            data={
+                "id": client.id,
+                "name": "",
+                "phone":"221555232",
+                "email": "brujita75@yahoo.com",
+            },
+        )
+
+        self.assertContains(response, "Por favor ingrese un nombre")
+        self.assertContains(response, "El teléfono debe comenzar con 54")
+        self.assertContains(response, "Por favor ingrese un email terminado en @vetsoft.com")
+
     def test_validation_invalid_name_with_special_characters(self):
         """Verifica si se muestra un mensaje de error al intentar crear un cliente con un nombre que contiene caracteres especiales."""
         response = self.client.post(

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -98,7 +98,7 @@ class ClientModelTest(TestCase):
         self.assertIn("name", errors)
 
     def test_updating_client_should_return_errors(self):
-
+        """Verifica que al editar un cliente, si se ingresa un campo vacío retorne errores"""
         Client.save_client(
             {
             "name": "Juan Sebastian Veron",

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -97,6 +97,33 @@ class ClientModelTest(TestCase):
         self.assertFalse(is_saved)
         self.assertIn("name", errors)
 
+    def test_updating_client_should_return_errors(self):
+
+        Client.save_client(
+            {
+            "name": "Juan Sebastian Veron",
+            "address": "13 y 44",
+            "phone": "54221555232",
+            "email": "brujita75@vetsoft.com",
+            }
+        )
+
+        client = Client.objects.get(pk=1)
+
+        is_saved, errors = client.update_client(
+            {
+            "name": "", #campo de nombre vacío para que muestre el error
+            "phone": "54221555232",
+            "address": "13 y 44",
+            "email": "brujita75@yahoo.com",
+            }
+        )
+
+        self.assertFalse(is_saved)
+        self.assertIn("name", errors)
+        self.assertIn("Por favor ingrese un nombre", errors["name"])
+
+
     def test_name_validation_with_special_characters(self):
     # Intenta guardar un cliente con un nombre que contiene caracteres especiales
         special_characters_name = "Juan&* Sebastian Veron"

--- a/app/views.py
+++ b/app/views.py
@@ -50,7 +50,7 @@ def clients_form(request, id=None):
             saved, errors = Client.save_client(request.POST)
         else:
             client = get_object_or_404(Client, pk=client_id)
-            client.update_client(request.POST)
+            saved, errors = client.update_client(request.POST)
 
         if saved:
             return redirect(reverse("clients_repo"))

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -302,6 +302,35 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         error_message = self.page.get_by_text("El teléfono debe ser numérico").is_visible()
         self.assertTrue(error_message)
 
+    def test_should_show_errors_when_editing_a_client(self):
+        """Verifica que al editar un cliente se muestren los errores correctamente"""
+        client = Client.objects.create(
+            name="Juan Sebastian Veron",
+            address="13 y 44",
+            phone="54221555232",
+            email="brujita75@vetsoft.com",
+        )
+
+        path = reverse("clients_edit", kwargs={"id": client.id})
+        self.page.goto(f"{self.live_server_url}{path}")
+
+        self.page.get_by_label("Nombre").fill("")   #Asigna un campo vacío
+        self.page.get_by_label("Teléfono").fill("221232555")    #Asigna un teléfono sin 54 adelante
+        self.page.get_by_label("Email").fill("@vetsoft.com")    #Asigna un email sin nada adelante del @
+        self.page.get_by_label("Dirección").fill("1 y 57")
+
+        self.page.get_by_role("button", name="Guardar").click()
+
+        expect(
+            self.page.get_by_text("Por favor ingrese un nombre")
+        ).to_be_visible()
+        expect(
+            self.page.get_by_text("El teléfono debe comenzar con 54")
+        ).to_be_visible()
+        expect(
+            self.page.get_by_text("Por favor ingrese un email valido")
+        ).to_be_visible()
+
 class MedicineCreateEditTestCase(PlaywrightTestCase):
     def test_should_be_able_to_create_a_new_medicine(self):
         self.page.goto(f"{self.live_server_url}{reverse('medi_form')}")


### PR DESCRIPTION
- Arreglo un bug que no permitía mostrar los errores de validación al editar un cliente
- Agrego un test de unidad, de integración y e2e para verificar que al editar un cliente con datos inválidos se muestren los errores correctamente