### PR TITLE
Bug fix/error input nombre

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -6,9 +6,9 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 
-def validate_name(name):
-    if not re.match(r'^[a-zA-Z\s]+$', name):
-        raise ValidationError('El nombre solo puede contener letras y espacios.')
+# def validate_name(name):
+#     if not re.match(r'^[a-zA-Z\s]+$', name):
+#         raise ValidationError('El nombre solo puede contener letras y espacios.')
 
 
 def validate_client(data):

--- a/app/models.py
+++ b/app/models.py
@@ -20,14 +20,14 @@ def validate_client(data):
     #phone = data.get("phone", "")
     email = data.get("email", "")
 
+
     if name == "":
         errors["name"] = "Por favor ingrese un nombre"
     else:
-        try:
-            validate_name(name)
-        except ValidationError as e:
-            errors["name"] = str(e)
+        if not re.match(r'^[a-zA-Z\s]+$', name):
+            errors["name"] = "El nombre solo puede contener letras y espacios."
 
+    
     if phone == "":
         errors["phone"] = "Por favor ingrese un teléfono"
     elif not phone.startswith("54"):
@@ -158,7 +158,15 @@ class Client(models.Model):
         email (str): La dirección de correo electrónico del cliente.
         address (str): La dirección física del cliente.
     """
-    name = models.CharField(max_length=100)
+    name = models.CharField(
+        max_length=100,
+        validators=[
+            RegexValidator(
+                regex=r'^[a-zA-Z\s]+$',
+                message="El nombre solo puede contener letras y espacios.",
+            ),
+        ],
+    )
     phone = models.BigIntegerField(
         validators=[
             RegexValidator(

--- a/app/models.py
+++ b/app/models.py
@@ -1,10 +1,8 @@
 import re
 
-from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db import models
 from django.utils.translation import gettext_lazy as _
-
 
 # def validate_name(name):
 #     if not re.match(r'^[a-zA-Z\s]+$', name):

--- a/app/templates/clients/form.html
+++ b/app/templates/clients/form.html
@@ -26,7 +26,7 @@
                         id="name"
                         name="name"
                         value="{{client.name}}"
-                        class="form-control"
+                        class="form-control {% if errors.name %}is-invalid{% endif %}"
                         required/>
 
                     {% if errors.name %}

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -209,8 +209,14 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         expect(self.page.get_by_text("54221555232")).to_be_visible()
         expect(self.page.get_by_text("brujita75@vetsoft.com")).to_be_visible()
         expect(self.page.get_by_text("13 y 44")).to_be_visible()
-
+   
+    # Test: Verificar visibilidad de mensajes de error en formulario inválido
     def test_should_view_errors_if_form_is_invalid(self):
+        """
+        Verifica la visibilidad de los mensajes de error cuando se intenta guardar
+        un formulario con datos inválidos en cualquier campo.
+        """
+        
         self.page.goto(f"{self.live_server_url}{reverse('clients_form')}")
 
         expect(self.page.get_by_role("form")).to_be_visible()
@@ -241,6 +247,36 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
             self.page.get_by_text("Por favor ingrese un email valido")
         ).to_be_visible()
 
+    
+    # Test: Verificar mensaje de error para nombre inválido con caracteres especiales
+    def test_should_display_error_for_invalid_name_input(self):
+        """
+        Verifica si se muestra un mensaje de error al intentar crear un cliente
+        con un nombre que contiene caracteres especiales.
+        """        
+        
+        self.page.goto(f"{self.live_server_url}{reverse('clients_form')}")
+
+        expect(self.page.get_by_role("form")).to_be_visible()
+
+        self.page.get_by_role("button", name="Guardar").click()
+
+        expect(self.page.get_by_text("Por favor ingrese un nombre")).to_be_visible()
+        expect(self.page.get_by_text("Por favor ingrese un teléfono")).to_be_visible()
+        expect(self.page.get_by_text("Por favor ingrese un email")).to_be_visible()
+
+        self.page.get_by_label("Nombre").fill("Juan# Sebastian Veron")  # Nombre con caracteres especiales
+        self.page.get_by_label("Teléfono").fill("54221555232")
+        self.page.get_by_label("Email").fill("brujita75@vetsoft.com")
+        self.page.get_by_label("Dirección").fill("13 y 44")
+
+        self.page.get_by_role("button", name="Guardar").click()
+
+        expect(self.page.get_by_text("El nombre solo puede contener letras y espacios")).to_be_visible()
+
+        expect(self.page.get_by_text("Por favor ingrese un nombre")).not_to_be_visible()
+        expect(self.page.get_by_text("Por favor ingrese un teléfono")).not_to_be_visible()
+        expect(self.page.get_by_text("Por favor ingrese un email valido")).not_to_be_visible()
 
     def test_should_be_able_to_edit_a_client(self):
         client = Client.objects.create(

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -229,6 +229,9 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
 
         self.page.get_by_role("button", name="Guardar").click()
 
+        # Verificar que el mensaje de error para el nombre no desaparezca
+        expect(self.page.get_by_text("El nombre solo puede contener letras y espacios")).to_be_visible()
+        
         expect(self.page.get_by_text("Por favor ingrese un nombre")).not_to_be_visible()
         expect(
             self.page.get_by_text("Por favor ingrese un teléfono")

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -227,26 +227,6 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         expect(self.page.get_by_text("Por favor ingrese un teléfono")).to_be_visible()
         expect(self.page.get_by_text("Por favor ingrese un email")).to_be_visible()
 
-       # Prueba agregar un nombre inválido
-        self.page.get_by_label("Nombre").fill("12345")  # Nombre inválido que no contiene solo letras y espacios
-        self.page.get_by_label("Teléfono").fill("54221555232")
-        self.page.get_by_label("Email").fill("brujita75")
-        self.page.get_by_label("Dirección").fill("13 y 44")
-
-        self.page.get_by_role("button", name="Guardar").click()
-
-        # Verificar que el mensaje de error para el nombre no desaparezca
-        expect(self.page.get_by_text("El nombre solo puede contener letras y espacios")).to_be_visible()
-        
-        expect(self.page.get_by_text("Por favor ingrese un nombre")).not_to_be_visible()
-        expect(
-            self.page.get_by_text("Por favor ingrese un teléfono")
-        ).not_to_be_visible()
-
-        expect(
-            self.page.get_by_text("Por favor ingrese un email valido")
-        ).to_be_visible()
-
     
     # Test: Verificar mensaje de error para nombre inválido con caracteres especiales
     def test_should_display_error_for_invalid_name_input(self):
@@ -257,13 +237,6 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         
         self.page.goto(f"{self.live_server_url}{reverse('clients_form')}")
 
-        expect(self.page.get_by_role("form")).to_be_visible()
-
-        self.page.get_by_role("button", name="Guardar").click()
-
-        expect(self.page.get_by_text("Por favor ingrese un nombre")).to_be_visible()
-        expect(self.page.get_by_text("Por favor ingrese un teléfono")).to_be_visible()
-        expect(self.page.get_by_text("Por favor ingrese un email")).to_be_visible()
 
         self.page.get_by_label("Nombre").fill("Juan# Sebastian Veron")  # Nombre con caracteres especiales
         self.page.get_by_label("Teléfono").fill("54221555232")
@@ -273,10 +246,6 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         self.page.get_by_role("button", name="Guardar").click()
 
         expect(self.page.get_by_text("El nombre solo puede contener letras y espacios")).to_be_visible()
-
-        expect(self.page.get_by_text("Por favor ingrese un nombre")).not_to_be_visible()
-        expect(self.page.get_by_text("Por favor ingrese un teléfono")).not_to_be_visible()
-        expect(self.page.get_by_text("Por favor ingrese un email valido")).not_to_be_visible()
 
     def test_should_be_able_to_edit_a_client(self):
         client = Client.objects.create(


### PR DESCRIPTION
Soluciono error que no se mostraba el mensaje de error cuando se ingresaban caracteres especiales en el input del nombre del cliente y agrego test e2e.